### PR TITLE
Enhance utf-8 atom support

### DIFF
--- a/src/main/scala/scalang/node/ScalaTermDecoder.scala
+++ b/src/main/scala/scalang/node/ScalaTermDecoder.scala
@@ -126,11 +126,7 @@ class ScalaTermDecoder(peer : Symbol, factory : TypeFactory, decoder : TypeDecod
       case 100 => //atom OR boolean
         val len = buffer.readShort
         val str = ScalaTermDecoder.fastString(buffer, len)
-        CachedSymbol(str) match {
-          case 'true => true
-          case 'false => false
-          case atom => atom
-        }
+        atomOrBoolean(str)
       case 101 => //reference
         val node = readTerm(buffer).asInstanceOf[Symbol]
         val id = buffer.readInt
@@ -206,11 +202,7 @@ class ScalaTermDecoder(peer : Symbol, factory : TypeFactory, decoder : TypeDecod
       case 115 => //small atom
         val length = buffer.readUnsignedByte
         val str = ScalaTermDecoder.fastString(buffer, length)
-        CachedSymbol(str) match {
-          case 'true => true
-          case 'false => false
-          case atom => atom
-        }
+        atomOrBoolean(str)
       case 117 => //fun
         val numFree = buffer.readInt
         val pid = readTerm(buffer).asInstanceOf[Pid]
@@ -245,12 +237,12 @@ class ScalaTermDecoder(peer : Symbol, factory : TypeFactory, decoder : TypeDecod
         val len = buffer.readShort
         val bytes = new Array[Byte](len)
         buffer.readBytes(bytes)
-        CachedSymbol(new String(bytes, "UTF-8"))
+        atomOrBoolean(new String(bytes, "UTF-8"))
       case 119 => // small_atom_utf8_ext
         val len = buffer.readUnsignedByte
         val bytes = new Array[Byte](len)
         buffer.readBytes(bytes)
-        CachedSymbol(new String(bytes, "UTF-8"))
+        atomOrBoolean(new String(bytes, "UTF-8"))
       case 77 => //bit binary
         val length = buffer.readInt
         val bits = buffer.readUnsignedByte
@@ -342,4 +334,11 @@ class ScalaTermDecoder(peer : Symbol, factory : TypeFactory, decoder : TypeDecod
     }).toSeq
     new BigTuple(Seq(first) ++ elements)
   }
+
+  private def atomOrBoolean(str : String) = str match {
+    case "true" => true
+    case "false" => false
+    case str => CachedSymbol(str)
+  }
+
 }

--- a/src/test/scala/scalang/terms/ScalaTermDecoderSpec.scala
+++ b/src/test/scala/scalang/terms/ScalaTermDecoderSpec.scala
@@ -94,9 +94,39 @@ class ScalaTermDecoderSpec extends SpecificationWithJUnit {
         thing must ==(Reference(Symbol("nonode@nohost"), Seq(99,0,0), 0))
       }
 
-      "small atoms" in {
+      "read small atoms" in {
         val thing = decoder.readTerm(copiedBuffer(ByteArray(115,1,97)))
         thing must ==('a)
+      }
+
+      "read utf8 atoms" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(118,0,1,97)))
+        thing must ==('a)
+      }
+
+      "read small utf8 atoms" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,1,97)))
+        thing must ==('a)
+      }
+
+      "atom to boolean" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(100,0,4,116,114,117,101)))
+        thing must ==(true)
+      }
+
+      "small atom to boolean" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(115,4,116,114,117,101)))
+        thing must ==(true)
+      }
+
+      "utf8 atom to boolean" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(118,0,4,116,114,117,101)))
+        thing must ==(true)
+      }
+
+      "small utf8 atom to boolean" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,4,116,114,117,101)))
+        thing must ==(true)
       }
 
       "bit binaries" in {


### PR DESCRIPTION
When we decode a UTF-8 atom we need to treat 'true' and 'false' specially, like legacy atoms.

Added the tests to prove it this time.
