### PR TITLE
Speed up Erlang 20 atom decoding for Clouseau

### DIFF
--- a/src/main/scala/scalang/node/ScalaTermDecoder.scala
+++ b/src/main/scala/scalang/node/ScalaTermDecoder.scala
@@ -59,6 +59,20 @@ object ScalaTermDecoder {
     }
     result
   }
+
+  private val atomEmpty = Array[Byte]()
+  private val atomNull = Array[Byte](0x6e, 0x75, 0x6c, 0x6c)
+  private val atomNil = Array[Byte](0x6e, 0x69, 0x6c)
+  private val atomTrue = Array[Byte](0x74, 0x72, 0x75, 0x65)
+  private val atomFalse = Array[Byte](0x66, 0x61, 0x6c, 0x73, 0x65)
+  private val atomGenCast = Array[Byte](0x24, 0x67, 0x65, 0x6e, 0x5f, 0x63, 0x61, 0x73, 0x74)
+  private val atomGenCall = Array[Byte](0x24, 0x67, 0x65, 0x6e, 0x5f, 0x63, 0x61, 0x6c, 0x6c)
+  private val atomUpdate = Array[Byte](0x75, 0x70, 0x64, 0x61, 0x74, 0x65)
+  private val atomSearch = Array[Byte](0x73, 0x65, 0x61, 0x72, 0x63, 0x68)
+  private val atomMain = Array[Byte](0x6d, 0x61, 0x69, 0x6e)
+  private val atomRelevance = Array[Byte](0x72, 0x65, 0x6c, 0x65, 0x76, 0x61, 0x6e, 0x63, 0x65)
+  private val atomCleanup = Array[Byte](0x63, 0x6c, 0x65, 0x61, 0x6e, 0x75, 0x70)
+  private val atomClouseauNodeName = Array[Byte](0x63, 0x6c, 0x6f, 0x75, 0x73, 0x65, 0x61, 0x75, 0x40, 0x31, 0x32, 0x37, 0x2e, 0x30, 0x2e, 0x30, 0x2e, 0x31)
 }
 
 class ScalaTermDecoder(peer : Symbol, factory : TypeFactory, decoder : TypeDecoder = NoneTypeDecoder) extends OneToOneDecoder with Instrumented {
@@ -242,7 +256,35 @@ class ScalaTermDecoder(peer : Symbol, factory : TypeFactory, decoder : TypeDecod
         val len = buffer.readUnsignedByte
         val bytes = new Array[Byte](len)
         buffer.readBytes(bytes)
-        atomOrBoolean(new String(bytes, "UTF-8"))
+        if (java.util.Arrays.equals(bytes, ScalaTermDecoder.atomEmpty)) {
+           CachedSymbol("")
+        } else if (java.util.Arrays.equals(bytes, ScalaTermDecoder.atomTrue)) {
+           true
+        } else if (java.util.Arrays.equals(bytes, ScalaTermDecoder.atomFalse)) {
+           false
+       } else if (java.util.Arrays.equals(bytes, ScalaTermDecoder.atomNull) ) {
+           CachedSymbol("null")
+       } else if (java.util.Arrays.equals(bytes, ScalaTermDecoder.atomNil) ) {
+           CachedSymbol("nil")
+        } else if (java.util.Arrays.equals(bytes, ScalaTermDecoder.atomGenCast) ) {
+           CachedSymbol("$gen_cast")
+        } else if (java.util.Arrays.equals(bytes, ScalaTermDecoder.atomGenCall) ) {
+           CachedSymbol("$gen_call")
+        } else if (java.util.Arrays.equals(bytes, ScalaTermDecoder.atomUpdate) ) {
+           CachedSymbol("update")
+        }  else if (java.util.Arrays.equals(bytes, ScalaTermDecoder.atomSearch) ) {
+           CachedSymbol("search")
+        }  else if (java.util.Arrays.equals(bytes, ScalaTermDecoder.atomMain) ) {
+           CachedSymbol("main")
+        }  else if (java.util.Arrays.equals(bytes, ScalaTermDecoder.atomRelevance) ) {
+           CachedSymbol("relevance")
+        }  else if (java.util.Arrays.equals(bytes, ScalaTermDecoder.atomCleanup) ) {
+           CachedSymbol("cleanup")
+        } else if (java.util.Arrays.equals(bytes, ScalaTermDecoder.atomClouseauNodeName)) {
+           CachedSymbol("clouseau@127.0.0.1")
+        } else {
+            CachedSymbol(new String(bytes, "UTF-8"))
+        }
       case 77 => //bit binary
         val length = buffer.readInt
         val bits = buffer.readUnsignedByte

--- a/src/test/scala/scalang/terms/ScalaTermDecoderSpec.scala
+++ b/src/test/scala/scalang/terms/ScalaTermDecoderSpec.scala
@@ -124,9 +124,69 @@ class ScalaTermDecoderSpec extends SpecificationWithJUnit {
         thing must ==(true)
       }
 
-      "small utf8 atom to boolean" in {
+      "true utf8 atom" in {
         val thing = decoder.readTerm(copiedBuffer(ByteArray(119,4,116,114,117,101)))
         thing must ==(true)
+      }
+
+      "false utf8 atom" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,5,102,97,108,115,101)))
+        thing must ==(false)
+      }
+
+      "empty string utf8 atom" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,0)))
+        thing must ==(Symbol(""))
+      }
+
+      "nil utf8 atom" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,3,110,105,108)))
+        thing must ==('nil)
+      }
+
+      "null utf8 atom" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,4,110,117,108,108)))
+        thing must ==('null)
+      }
+
+      "gen_cast utf8 atom" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,9,36,103,101,110,95,99,97,115,116)))
+        thing must ==('$gen_cast)
+      }
+
+      "gen_call utf8 atom" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,9,36,103,101,110,95,99,97,108,108)))
+        thing must ==('$gen_call)
+      }
+
+      "update utf8 atom" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,6,117,112,100,97,116,101)))
+        thing must ==('update)
+      }
+
+      "search utf8 atom" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,6,115,101,97,114,99,104)))
+        thing must ==('search)
+      }
+
+      "main utf8 atom" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,4,109,97,105,110)))
+        thing must ==('main)
+      }
+
+      "relevance utf8 atom" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,9,114,101,108,101,118,97,110,99,101)))
+        thing must ==('relevance)
+      }
+
+      "cleanup utf8 atom" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,7,99,108,101,97,110,117,112)))
+        thing must ==('cleanup)
+      }
+
+     "clouseau utf8 atom node name" in {
+        val thing = decoder.readTerm(copiedBuffer(ByteArray(119,18,99,108,111,117,115,101,97,117,64,49,50,55,46,48,46,48,46,49)))
+        thing must ==(Symbol("clouseau@127.0.0.1"))
       }
 
       "bit binaries" in {


### PR DESCRIPTION
Erlang 20+ nodes send utf-8 encoded atoms. During decoding creating UTF-8
string take more time and also generates more garbage. This can result in
slowdown up to 20% compared to Erlang 17.

However since atoms are constant in most cases it is possible to compare the
raw byte represenation without decoding to a UTF-8 string and use an already
interned symbol without allocated any memory.

Performance testing was performed by running:
 search/test_lucene_queries.py::TestLuceneQueries::test_sort_ascending_string
benchmark request 2000 times in a row and getting the average:

```
N=2000

17: 2.13 (default)
   0.00736245012283
   0.00700633811951
   0.00743632125854
   0.00714290165901

17: with fix (the new code not used, just for comparison)
   0.00714632320404
   0.00771706545353
   0.00780687844753
   0.00737625157833

20: 2.13 (default)
   0.0100574611425
   0.00828588569164
   0.00841012430191
   0.00925046432018
   0.0104226925373

20: with fix
   0.00709199845791
   0.00675505518913
   0.00697762835026
   0.00712769651413
```

BugzID: 106679