### PR TITLE
Speed up Erlang 20 atom decoding

### DIFF
--- a/src/main/scala/scalang/node/ScalaTermDecoder.scala
+++ b/src/main/scala/scalang/node/ScalaTermDecoder.scala
@@ -235,14 +235,12 @@ class ScalaTermDecoder(peer : Symbol, factory : TypeFactory, decoder : TypeDecod
         ExportFun(module, function, arity)
       case 118 => // atom_utf8_ext
         val len = buffer.readShort
-        val bytes = new Array[Byte](len)
-        buffer.readBytes(bytes)
-        atomOrBoolean(new String(bytes, "UTF-8"))
+        val str = ScalaTermDecoder.fastString(buffer, len)
+        atomOrBoolean(str)
       case 119 => // small_atom_utf8_ext
         val len = buffer.readUnsignedByte
-        val bytes = new Array[Byte](len)
-        buffer.readBytes(bytes)
-        atomOrBoolean(new String(bytes, "UTF-8"))
+        val str = ScalaTermDecoder.fastString(buffer, len)
+        atomOrBoolean(str)
       case 77 => //bit binary
         val length = buffer.readInt
         val bits = buffer.readUnsignedByte


### PR DESCRIPTION
Erlang 20+ nodes send utf-8 encoded atoms. During decoding creating utf-8
strings takes more time and also generates more garbage. This can result in
slowdown up to 20% compared to Erlang 17.

Re-use the fastString decoder for utf-8 atoms but pass in an option which
explicitly check for non-ascii values. We can do this since we control the
nodes we know we shouldn't send utf-8  encoded atoms.

BugzID: 106679