### PR TITLE
Support big creation flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,33 +59,18 @@
         <repository>
             <id>CloudantPublicRepo</id>
             <name>Cloudant Public Repo</name>
-            <url>http://maven.cloudant.com/repo/</url>
-        </repository>
-        <repository>
-            <id>BoundaryPublicRepo</id>
-            <name>Boundary Public Repo</name>
-            <url>http://maven.boundary.com/artifactory/repo/</url>
-        </repository>
-        <repository>
-            <id>ScalaToolsMaven2Repository</id>
-            <name>Scala-Tools Maven2 Repository</name>
-            <url>http://scala-tools.org/repo-releases/</url>
-        </repository>
-        <repository>
-            <id>scala-tools.org</id>
-            <name>snapshots</name>
-            <url>http://scala-tools.org/repo-snapshots</url>
+            <url>https://maven.cloudant.com/repo/</url>
         </repository>
         <repository>
             <id>central</id>
             <name>Maven repository</name>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
-            <id>scala-tools-releases</id>
-            <url>http://scala-tools.org/repo-releases/</url>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
         </pluginRepository>
     </pluginRepositories>
     <build>
@@ -94,9 +79,9 @@
 
     <plugins>
       <plugin>
-        <groupId>org.scala-tools</groupId>
-        <artifactId>maven-scala-plugin</artifactId>
-        <version>2.15.2</version>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>cmain</id>
@@ -138,7 +123,6 @@
           </launchers>
         </configuration>
       </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/scala/scalang/epmd/EpmdDecoder.scala
+++ b/src/main/scala/scalang/epmd/EpmdDecoder.scala
@@ -25,10 +25,14 @@ class EpmdDecoder extends FrameDecoder {
     if (buffer.readableBytes < 1) return null
     val header = buffer.getByte(0)
     header match {
-      case 121 => //decode alive2 resp
+      case 118 | 121 => //decode alive2 resp
         if (buffer.readableBytes < 4) return null
         val result = buffer.getByte(1)
-        val creation = buffer.getUnsignedShort(2)
+        val creation = if (header == 118) {
+          buffer.getInt(2)
+        } else {
+          buffer.getUnsignedShort(2)
+        }
         buffer.skipBytes(4)
         AliveResp(result, creation)
       case 119 => //decode port2 resp

--- a/src/main/scala/scalang/epmd/EpmdDecoder.scala
+++ b/src/main/scala/scalang/epmd/EpmdDecoder.scala
@@ -25,14 +25,16 @@ class EpmdDecoder extends FrameDecoder {
     if (buffer.readableBytes < 1) return null
     val header = buffer.getByte(0)
     header match {
-      case 118 | 121 => //decode alive2 resp
+       case 118  => //decode alive2 resp
         if (buffer.readableBytes < 4) return null
         val result = buffer.getByte(1)
-        val creation = if (header == 118) {
-          buffer.getInt(2)
-        } else {
-          buffer.getUnsignedShort(2)
-        }
+        val creation = buffer.getInt(2)
+        buffer.skipBytes(4)
+        AliveResp(result, creation)
+      case 121 => //decode alive2 resp
+        if (buffer.readableBytes < 4) return null
+        val result = buffer.getByte(1)
+        val creation = buffer.getUnsignedShort(2)
         buffer.skipBytes(4)
         AliveResp(result, creation)
       case 119 => //decode port2 resp

--- a/src/main/scala/scalang/node/HandshakeMessages.scala
+++ b/src/main/scala/scalang/node/HandshakeMessages.scala
@@ -65,10 +65,12 @@ object DistributionFlags {
   val newFloats = 0x800
   val smallAtomTags = 0x4000
   val utf8Atoms = 0x10000
+  val dFlagBigCreation = 0x40000
 
   val default = extendedReferences | extendedPidsPorts |
     bitBinaries | newFloats | funTags | newFunTags |
-    distMonitor | distMonitorName | smallAtomTags | utf8Atoms
+    distMonitor | distMonitorName | smallAtomTags | utf8Atoms |
+    dFlagBigCreation
 }
 
 class ErlangAuthException(msg : String) extends Exception(msg)

--- a/src/main/scala/scalang/node/ScalaTermDecoder.scala
+++ b/src/main/scala/scalang/node/ScalaTermDecoder.scala
@@ -132,24 +132,27 @@ class ScalaTermDecoder(peer : Symbol, factory : TypeFactory, decoder : TypeDecod
         val id = buffer.readInt
         val creation = buffer.readUnsignedByte
         Reference(node, Seq(id), creation)
-      case 89 | 102 => //new port(erl 23), port
+      case 89 => //new port(erl 23)
         val node = readTerm(buffer).asInstanceOf[Symbol]
         val id = buffer.readInt
-        val creation = if (typeOrdinal == 89) {
-            buffer.readInt
-          } else {
-            buffer.readByte
-          }
+        val creation = buffer.readInt
         Port(node, id, creation)
-      case 88 | 103 => //new pid(erl 23), pid
+      case 102 => //port
+        val node = readTerm(buffer).asInstanceOf[Symbol]
+        val id = buffer.readInt
+        val creation = buffer.readByte
+        Port(node, id, creation)
+      case 88 => //new pid(erl 23)
         val node = readTerm(buffer).asInstanceOf[Symbol]
         val id = buffer.readInt
         val serial = buffer.readInt
-        val creation = if (typeOrdinal == 88) {
-            buffer.readInt
-          } else {
-            buffer.readUnsignedByte
-          }
+        val creation = buffer.readInt
+        Pid(node,id,serial,creation)
+      case 103 => //pid
+        val node = readTerm(buffer).asInstanceOf[Symbol]
+        val id = buffer.readInt
+        val serial = buffer.readInt
+        val creation = buffer.readUnsignedByte
         Pid(node,id,serial,creation)
       case 104 => //small tuple -- will be a scala tuple up to size 22
         val arity = buffer.readUnsignedByte
@@ -199,14 +202,18 @@ class ScalaTermDecoder(peer : Symbol, factory : TypeFactory, decoder : TypeDecod
           val bytes = readReversed(length, buffer)
           BigInt(sign, bytes)
         }
-      case 90 | 114 => //newer reference(erl 23), new reference
+      case 90 => //newer reference(erl 23)
         val length = buffer.readShort
         val node = readTerm(buffer).asInstanceOf[Symbol]
-        val creation = if (typeOrdinal == 90) {
+        val creation = buffer.readInt
+        val id = (for(n <- (0 until length)) yield {
           buffer.readInt
-        } else {
-          buffer.readUnsignedByte
-        }
+        }).toSeq
+        Reference(node, id, creation)
+      case 114 => //new reference
+        val length = buffer.readShort
+        val node = readTerm(buffer).asInstanceOf[Symbol]
+        val creation = buffer.readUnsignedByte
         val id = (for(n <- (0 until length)) yield {
           buffer.readInt
         }).toSeq

--- a/src/main/scala/scalang/node/ScalaTermDecoder.scala
+++ b/src/main/scala/scalang/node/ScalaTermDecoder.scala
@@ -132,16 +132,24 @@ class ScalaTermDecoder(peer : Symbol, factory : TypeFactory, decoder : TypeDecod
         val id = buffer.readInt
         val creation = buffer.readUnsignedByte
         Reference(node, Seq(id), creation)
-      case 102 => //port
+      case 89 | 102 => //new port(erl 23), port
         val node = readTerm(buffer).asInstanceOf[Symbol]
         val id = buffer.readInt
-        val creation = buffer.readByte
+        val creation = if (typeOrdinal == 89) {
+            buffer.readInt
+          } else {
+            buffer.readByte
+          }
         Port(node, id, creation)
-      case 103 => //pid
+      case 88 | 103 => //new pid(erl 23), pid
         val node = readTerm(buffer).asInstanceOf[Symbol]
         val id = buffer.readInt
         val serial = buffer.readInt
-        val creation = buffer.readUnsignedByte
+        val creation = if (typeOrdinal == 88) {
+            buffer.readInt
+          } else {
+            buffer.readUnsignedByte
+          }
         Pid(node,id,serial,creation)
       case 104 => //small tuple -- will be a scala tuple up to size 22
         val arity = buffer.readUnsignedByte
@@ -191,10 +199,14 @@ class ScalaTermDecoder(peer : Symbol, factory : TypeFactory, decoder : TypeDecod
           val bytes = readReversed(length, buffer)
           BigInt(sign, bytes)
         }
-      case 114 => //new reference
+      case 90 | 114 => //newer reference(erl 23), new reference
         val length = buffer.readShort
         val node = readTerm(buffer).asInstanceOf[Symbol]
-        val creation = buffer.readUnsignedByte
+        val creation = if (typeOrdinal == 90) {
+          buffer.readInt
+        } else {
+          buffer.readUnsignedByte
+        }
         val id = (for(n <- (0 until length)) yield {
           buffer.readInt
         }).toSeq

--- a/src/main/scala/scalang/node/ScalaTermEncoder.scala
+++ b/src/main/scala/scalang/node/ScalaTermEncoder.scala
@@ -89,6 +89,14 @@ class ScalaTermEncoder(peer: Symbol, encoder: TypeEncoder = NoneTypeEncoder) ext
       writeAtom(buffer, 'false)
     case s : Symbol =>
       writeAtom(buffer, s)
+    case Reference(node, id, creation : Int) => //we only emit new references
+      buffer.writeByte(90)
+      buffer.writeShort(id.length)
+      writeAtom(buffer, node)
+      buffer.writeInt(creation)
+      for (i <- id) {
+        buffer.writeInt(i)
+      }
     case Reference(node, id, creation) => //we only emit new references
       buffer.writeByte(114)
       buffer.writeShort(id.length)
@@ -97,11 +105,22 @@ class ScalaTermEncoder(peer: Symbol, encoder: TypeEncoder = NoneTypeEncoder) ext
       for (i <- id) {
         buffer.writeInt(i)
       }
+    case Port(node, id, creation : Int) =>
+      buffer.writeByte(89)
+      writeAtom(buffer, node)
+      buffer.writeInt(id)
+      buffer.writeInt(creation)
     case Port(node, id, creation) =>
       buffer.writeByte(102)
       writeAtom(buffer, node)
       buffer.writeInt(id)
       buffer.writeByte(creation)
+    case Pid(node, id, serial, creation : Int) =>
+      buffer.writeByte(88)
+      writeAtom(buffer, node)
+      buffer.writeInt(id)
+      buffer.writeInt(serial)
+      buffer.writeInt(creation)
     case Pid(node, id, serial, creation) =>
       buffer.writeByte(103)
       writeAtom(buffer, node)

--- a/src/main/scala/scalang/node/ScalaTermEncoder.scala
+++ b/src/main/scala/scalang/node/ScalaTermEncoder.scala
@@ -89,7 +89,7 @@ class ScalaTermEncoder(peer: Symbol, encoder: TypeEncoder = NoneTypeEncoder) ext
       writeAtom(buffer, 'false)
     case s : Symbol =>
       writeAtom(buffer, s)
-    case Reference(node, id, creation : Int) => //we only emit new references
+    case Reference(node, id, creation) => //we only emit new references
       buffer.writeByte(90)
       buffer.writeShort(id.length)
       writeAtom(buffer, node)
@@ -97,36 +97,17 @@ class ScalaTermEncoder(peer: Symbol, encoder: TypeEncoder = NoneTypeEncoder) ext
       for (i <- id) {
         buffer.writeInt(i)
       }
-    case Reference(node, id, creation) => //we only emit new references
-      buffer.writeByte(114)
-      buffer.writeShort(id.length)
-      writeAtom(buffer, node)
-      buffer.writeByte(creation)
-      for (i <- id) {
-        buffer.writeInt(i)
-      }
-    case Port(node, id, creation : Int) =>
+    case Port(node, id, creation) =>
       buffer.writeByte(89)
       writeAtom(buffer, node)
       buffer.writeInt(id)
       buffer.writeInt(creation)
-    case Port(node, id, creation) =>
-      buffer.writeByte(102)
-      writeAtom(buffer, node)
-      buffer.writeInt(id)
-      buffer.writeByte(creation)
-    case Pid(node, id, serial, creation : Int) =>
+    case Pid(node, id, serial, creation) =>
       buffer.writeByte(88)
       writeAtom(buffer, node)
       buffer.writeInt(id)
       buffer.writeInt(serial)
       buffer.writeInt(creation)
-    case Pid(node, id, serial, creation) =>
-      buffer.writeByte(103)
-      writeAtom(buffer, node)
-      buffer.writeInt(id)
-      buffer.writeInt(serial)
-      buffer.writeByte(creation)
     case Fun(pid, module, index, uniq, vars) =>
       buffer.writeByte(117)
       buffer.writeInt(vars.length)

--- a/src/main/scala/scalang/node/ScalaTermEncoder.scala
+++ b/src/main/scala/scalang/node/ScalaTermEncoder.scala
@@ -63,7 +63,7 @@ class ScalaTermEncoder(peer: Symbol, encoder: TypeEncoder = NoneTypeEncoder) ext
         case DemonitorMessage(monitoring, monitored, ref) =>
           encodeObject(buffer, (20, monitoring, monitored, ref))
         case MonitorExitMessage(monitored, monitoring, ref, reason) =>
-          encodeObject(buffer, (21, monitoring, monitored, ref, reason))
+          encodeObject(buffer, (21, monitored, monitoring, ref, reason))
       }
 
       buffer


### PR DESCRIPTION
Erlang 23 and above requires support for DFLAG_BIG_CREATION.
The node understands big node creation tags NEW_PID_EXT, NEW_PORT_EXT
and NEWER_REFERENCE_EXT. So that means we need to be able to decode
and encode those new formats.