### PR TITLE
Support OTP 25

### DIFF
--- a/src/main/scala/scalang/node/ClientHandshakeHandler.scala
+++ b/src/main/scala/scalang/node/ClientHandshakeHandler.scala
@@ -30,7 +30,7 @@ import scala.math._
 import scala.collection.JavaConversions._
 import java.security.{SecureRandom,MessageDigest}
 
-class ClientHandshakeHandler(name : Symbol, cookie : String, posthandshake : (Symbol,ChannelPipeline) => Unit) extends HandshakeHandler(posthandshake) {
+class ClientHandshakeHandler(name : Symbol, cookie : String, creation : Int, posthandshake : (Symbol,ChannelPipeline) => Unit) extends HandshakeHandler(posthandshake) {
   states(
     state('disconnected, {
       case ConnectedMessage =>
@@ -51,9 +51,9 @@ class ClientHandshakeHandler(name : Symbol, cookie : String, posthandshake : (Sy
     }),
 
     state('status_ok, {
-      case ChallengeMessage(version, flags, c, name) =>
+      case ChallengeMessage(flags, challenge, creation, name) =>
         peer = Symbol(name)
-        sendChallengeReply(c)
+        sendChallengeReply(challenge)
         'reply_sent
     }),
 
@@ -79,7 +79,7 @@ class ClientHandshakeHandler(name : Symbol, cookie : String, posthandshake : (Sy
   protected def sendName {
     val channel = ctx.getChannel
     val future = Channels.future(channel)
-    val msg = NameMessage(5, DistributionFlags.default, name.name)
+    val msg = NameMessage(DistributionFlags.default, creation, name.name)
     ctx.sendDownstream(new DownstreamMessageEvent(channel,future,msg,null))
   }
 

--- a/src/main/scala/scalang/node/ErlangNodeClient.scala
+++ b/src/main/scala/scalang/node/ErlangNodeClient.scala
@@ -50,7 +50,7 @@ class ErlangNodeClient(
       pipeline.addLast("handshakeFramer", new LengthFieldBasedFrameDecoder(Short.MaxValue, 0, 2, 0, 2))
       pipeline.addLast("handshakeDecoder", handshakeDecoder)
       pipeline.addLast("handshakeEncoder", new HandshakeEncoder)
-      pipeline.addLast("handshakeHandler", new ClientHandshakeHandler(node.name, node.cookie, node.posthandshake))
+      pipeline.addLast("handshakeHandler", new ClientHandshakeHandler(node.name, node.cookie, node.creation, node.posthandshake))
       pipeline.addLast("erlangFramer", new LengthFieldBasedFrameDecoder(Int.MaxValue, 0, 4, 0, 4))
       pipeline.addLast("encoderFramer", new LengthFieldPrepender(4))
       pipeline.addLast("erlangDecoder", new ScalaTermDecoder(peer, typeFactory, typeDecoder))

--- a/src/main/scala/scalang/node/ErlangNodeServer.scala
+++ b/src/main/scala/scalang/node/ErlangNodeServer.scala
@@ -37,7 +37,7 @@ class ErlangNodeServer(node : ErlangNode, typeFactory : TypeFactory, typeEncoder
       pipeline.addLast("handshakeFramer", new LengthFieldBasedFrameDecoder(Short.MaxValue, 0, 2, 0, 2))
       pipeline.addLast("handshakeDecoder", new HandshakeDecoder)
       pipeline.addLast("handshakeEncoder", new HandshakeEncoder)
-      pipeline.addLast("handshakeHandler", new ServerHandshakeHandler(node.name, node.cookie, node.posthandshake))
+      pipeline.addLast("handshakeHandler", new ServerHandshakeHandler(node.name, node.cookie, node.creation, node.posthandshake))
       pipeline.addLast("erlangFramer", new LengthFieldBasedFrameDecoder(Int.MaxValue, 0, 4, 0, 4))
       pipeline.addLast("encoderFramer", new LengthFieldPrepender(4))
       pipeline.addLast("erlangDecoder", new ScalaTermDecoder('server, typeFactory, typeDecoder))

--- a/src/main/scala/scalang/node/HandshakeEncoder.scala
+++ b/src/main/scala/scalang/node/HandshakeEncoder.scala
@@ -24,7 +24,18 @@ class HandshakeEncoder extends OneToOneEncoder {
 
   def encode(ctx : ChannelHandlerContext, channel : Channel, obj : Any) : Object = {
     obj match {
-      case NameMessage(version, flags, name) =>
+      case NameMessage(flags, creation, name) =>
+        val bytes = name.getBytes
+        val length = 1 + 8 + 4 + 2 + bytes.length
+        val buffer = ChannelBuffers.dynamicBuffer(length+2)
+        buffer.writeShort(length)
+        buffer.writeByte(78)
+        buffer.writeLong(flags)
+        buffer.writeInt(creation)
+        buffer.writeShort(bytes.length)
+        buffer.writeBytes(bytes)
+        buffer
+      case NameMessageV5(version, flags, name) =>
         val bytes = name.getBytes
         val length = 7 + bytes.length
         val buffer = ChannelBuffers.dynamicBuffer(length+2)
@@ -42,7 +53,19 @@ class HandshakeEncoder extends OneToOneEncoder {
         buffer.writeByte(115)
         buffer.writeBytes(bytes)
         buffer
-      case ChallengeMessage(version, flags, challenge, name) =>
+      case ChallengeMessage(flags, challenge, creation, name) =>
+        val bytes = name.getBytes
+        val length = 1 + 8 + 4 + 4 + 2 + bytes.length
+        val buffer = ChannelBuffers.dynamicBuffer(length+2)
+        buffer.writeShort(length)
+        buffer.writeByte(78)
+        buffer.writeLong(flags)
+        buffer.writeInt(challenge)
+        buffer.writeInt(creation)
+        buffer.writeShort(bytes.length)
+        buffer.writeBytes(bytes)
+        buffer
+      case ChallengeMessageV5(version, flags, challenge, name) =>
         val bytes = name.getBytes
         val length = 11 + bytes.length
         val buffer = ChannelBuffers.dynamicBuffer(length+2)

--- a/src/main/scala/scalang/node/HandshakeMessages.scala
+++ b/src/main/scala/scalang/node/HandshakeMessages.scala
@@ -65,12 +65,16 @@ object DistributionFlags {
   val newFloats = 0x800
   val smallAtomTags = 0x4000
   val utf8Atoms = 0x10000
-  val dFlagBigCreation = 0x40000
+  val mapTag = 0x20000
+  val bigCreation = 0x40000
+  val handshake23 = 0x1000000
 
-  val default = extendedReferences | extendedPidsPorts |
+  val defaultV5 = extendedReferences | extendedPidsPorts |
     bitBinaries | newFloats | funTags | newFunTags |
     distMonitor | distMonitorName | smallAtomTags | utf8Atoms |
-    dFlagBigCreation
+    bigCreation
+
+  val default = defaultV5 | exportPtrTag | mapTag | handshake23
 }
 
 class ErlangAuthException(msg : String) extends Exception(msg)

--- a/src/main/scala/scalang/node/HandshakeMessages.scala
+++ b/src/main/scala/scalang/node/HandshakeMessages.scala
@@ -20,11 +20,15 @@ import scala.collection.mutable.StringBuilder
 
 case object ConnectedMessage
 
-case class NameMessage(version : Short, flags : Int, name : String)
+case class NameMessage(flags : Long, creation : Int, name : String)
+
+case class NameMessageV5(version : Short, flags : Int, name : String)
 
 case class StatusMessage(status : String)
 
-case class ChallengeMessage(version : Short, flags : Int, challenge : Int, name : String)
+case class ChallengeMessage(flags : Long, challenge : Int, creation : Int, name : String)
+
+case class ChallengeMessageV5(version : Short, flags : Int, challenge : Int, name : String)
 
 case class ChallengeReplyMessage(challenge : Int, digest : Array[Byte]) {
   override def toString : String = {

--- a/src/test/scala/scalang/node/ClientHandshakeHandlerSpec.scala
+++ b/src/test/scala/scalang/node/ClientHandshakeHandlerSpec.scala
@@ -11,17 +11,18 @@ import netty.handler.codec.embedder.TwoWayCodecEmbedder
 class ClientHandshakeHandlerSpec extends SpecificationWithJUnit {
   val cookie = "DRSJLFJLGIYPEAVFYFCY"
   val node = Symbol("tmp@moonpolysoft.local")
+  val creation = 1
 
   "ClientHandshakeHandler" should {
     "complete a standard handshake" in {
-      val handshake = new ClientHandshakeHandler(node, cookie, { (peer : Symbol, p : ChannelPipeline) =>
+      val handshake = new ClientHandshakeHandler(node, cookie, creation, { (peer : Symbol, p : ChannelPipeline) =>
 
       })
       val embedder = new TwoWayCodecEmbedder[Any](handshake)
       val nameMsg = embedder.poll
-      nameMsg must beLike { case NameMessage(5, _, node) => true }
+      nameMsg must beLike { case NameMessage(_, _, node) => true }
       embedder.upstreamMessage(StatusMessage("ok"))
-      embedder.upstreamMessage(ChallengeMessage(5, 32765, 15000, "tmp@blah"))
+      embedder.upstreamMessage(ChallengeMessage(32765, 15000, creation, "tmp@blah"))
       val respMsg = embedder.poll
       var challenge = 0
       respMsg must beLike { case ChallengeReplyMessage(c, digest) =>

--- a/src/test/scala/scalang/node/HandshakeDecoderSpec.scala
+++ b/src/test/scala/scalang/node/HandshakeDecoderSpec.scala
@@ -13,11 +13,11 @@ class HandshakeDecoderSpec extends SpecificationWithJUnit {
       val decoder = new HandshakeDecoder
       val embedder = new DecoderEmbedder[NameMessage](decoder)
 
-      val bytes = ByteArray(110, 0,5, 0,0,127,253, 116,109,112,64,98,108,97,104)
+      val bytes = ByteArray(78, 0,0,0,0,0,0,127,253, 0,0,0,1, 0,8, 116,109,112,64,98,108,97,104)
       val buffer = copiedBuffer(bytes)
       embedder.offer(buffer)
       val msg = embedder.poll
-      msg must ==(NameMessage(5, 32765, "tmp@blah"))
+      msg must ==(NameMessage(32765, 1, "tmp@blah"))
 
       decoder.mode must ==('challenge) //decoding a name message should trigger a state change
     }
@@ -37,11 +37,11 @@ class HandshakeDecoderSpec extends SpecificationWithJUnit {
       val decoder = new HandshakeDecoder
       val embedder = new DecoderEmbedder[ChallengeMessage](decoder)
       decoder.mode = 'challenge
-      val bytes = ByteArray(110, 0,5, 0,0,127,253, 0,1,56,213, 116,109,112,64,98,108,97,104)
+      val bytes = ByteArray(78, 0,0,0,0,0,0,127,253, 0,1,56,213, 0,0,0,1, 0,8, 116,109,112,64,98,108,97,104)
       val buffer = copiedBuffer(bytes)
       embedder.offer(buffer)
       val msg = embedder.poll
-      msg must ==(ChallengeMessage(5, 32765, 80085, "tmp@blah"))
+      msg must ==(ChallengeMessage(32765, 80085, 1, "tmp@blah"))
     }
 
     "decode reply messages" in {

--- a/src/test/scala/scalang/node/HandshakeEncoderSpec.scala
+++ b/src/test/scala/scalang/node/HandshakeEncoderSpec.scala
@@ -13,11 +13,11 @@ class HandshakeEncoderSpec extends SpecificationWithJUnit {
     "encode name messages" in {
       val encoder = new HandshakeEncoder
       val embedder = new EncoderEmbedder[ChannelBuffer](encoder)
-      embedder.offer(NameMessage(5, 32765, "tmp@blah"))
+      embedder.offer(NameMessage(32765, 1, "tmp@blah"))
 
       val buffer = embedder.poll
       val bytes = buffer.array
-      bytes.deep must ==(ByteArray(0,15, 110, 0,5, 0,0,127,253, 116,109,112,64,98,108,97,104).deep)
+      bytes.deep must ==(ByteArray(0,23, 78, 0,0,0,0,0,0,127,253, 0,0,0,1, 0,8, 116,109,112,64,98,108,97,104).deep)
     }
 
     "encode status messages" in {
@@ -33,11 +33,11 @@ class HandshakeEncoderSpec extends SpecificationWithJUnit {
     "encode challenge messages" in {
       val encoder = new HandshakeEncoder
       val embedder = new EncoderEmbedder[ChannelBuffer](encoder)
-      embedder.offer(ChallengeMessage(5, 32765, 80085, "tmp@blah"))
+      embedder.offer(ChallengeMessage(32765, 80085, 1, "tmp@blah"))
 
       val buffer = embedder.poll
       val bytes = buffer.array
-      bytes.deep must ==(ByteArray(0,19, 110, 0,5, 0,0,127,253, 0,1,56,213, 116,109,112,64,98,108,97,104).deep)
+      bytes.deep must ==(ByteArray(0,27, 78, 0,0,0,0,0,0,127,253, 0,1,56,213, 0,0,0,1, 0,8, 116,109,112,64,98,108,97,104).deep)
     }
 
     "encode challenge reply messages" in {

--- a/src/test/scala/scalang/node/ServerHandshakeHandlerSpec.scala
+++ b/src/test/scala/scalang/node/ServerHandshakeHandlerSpec.scala
@@ -12,19 +12,20 @@ import netty.handler.codec.embedder.TwoWayCodecEmbedder
 
 class ServerHandshakeHandlerSpec extends SpecificationWithJUnit {
   val cookie = "DRSJLFJLGIYPEAVFYFCY"
+  val creation = 1
 
   "ServerHandshakeHandler" should {
     "complete a standard handshake" in {
-      val handshake = new ServerHandshakeHandler(Symbol("tmp@blah"), cookie, { (peer : Symbol, p : ChannelPipeline) =>
+      val handshake = new ServerHandshakeHandler(Symbol("tmp@blah"), cookie, creation, { (peer : Symbol, p : ChannelPipeline) =>
 
       })
       val embedder = new TwoWayCodecEmbedder[Any](handshake)
-      embedder.upstreamMessage(NameMessage(5, 32765, "tmp@moonpolysoft.local"))
+      embedder.upstreamMessage(NameMessage(32765, creation, "tmp@moonpolysoft.local"))
       val status = embedder.poll
       status must ==(StatusMessage("ok"))
       var challenge = 0
       val challengeMsg = embedder.poll
-      challengeMsg must beLike { case ChallengeMessage(5, _, c : Int, _) =>
+      challengeMsg must beLike { case ChallengeMessage(_, c : Int, _, _) =>
         challenge = c
         true }
       val md5 = MessageDigest.getInstance("MD5")


### PR DESCRIPTION
Parent: https://github.ibm.com/cloudant/dbcore/issues/376

- Add distribution flags required by OTP 25
- Implement version 6 `name` and `challenge` messages