### PR TITLE
Add distribution flags required by OTP 26

### DIFF
--- a/src/main/scala/scalang/node/HandshakeMessages.scala
+++ b/src/main/scala/scalang/node/HandshakeMessages.scala
@@ -72,13 +72,16 @@ object DistributionFlags {
   val mapTag = 0x20000
   val bigCreation = 0x40000
   val handshake23 = 0x1000000
+  val unlinkId = 0x2000000
+  val v4PidsRefs = 0x4L << 32
 
   val defaultV5 = extendedReferences | extendedPidsPorts |
     bitBinaries | newFloats | funTags | newFunTags |
     distMonitor | distMonitorName | smallAtomTags | utf8Atoms |
     bigCreation
 
-  val default = defaultV5 | exportPtrTag | mapTag | handshake23
+  val default = defaultV5 | exportPtrTag | mapTag | handshake23 |
+      unlinkId | v4PidsRefs
 }
 
 class ErlangAuthException(msg : String) extends Exception(msg)

--- a/src/test/resources/echo.escript
+++ b/src/test/resources/echo.escript
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -smp enable -sname test@localhost -setcookie test
+%%! -sname echo@localhost -setcookie test
 
 main([]) ->
   register(echo, self()),

--- a/src/test/resources/echo.escript
+++ b/src/test/resources/echo.escript
@@ -4,6 +4,11 @@
 main([]) ->
   register(echo, self()),
   io:format("ok~n"),
+  loop().
+
+loop() ->
   receive
+    {_Pid, stop} -> exit(stopped);
     {Pid, Msg} -> Pid ! Msg
-  end.
+  end,
+  loop().

--- a/src/test/resources/link_delivery.escript
+++ b/src/test/resources/link_delivery.escript
@@ -1,13 +1,13 @@
 #!/usr/bin/env escript
-%%! -smp enable -sname test@localhost -setcookie test
+%%! -sname link_delivery@localhost -setcookie test
 
 main([]) ->
   process_flag(trap_exit, true),
-  Pid = spawn_link(fun() ->
+  _Pid = spawn_link(fun() ->
       process_flag(trap_exit, true),
-      {mbox,scala@localhost} ! self(),
+      {mbox_break, scala_break@localhost} ! self(),
       receive
-        {'EXIT', _From, Reason} -> {scala, scala@localhost} ! Reason;
+        {'EXIT', _From, Reason} -> {scala_break, scala_break@localhost} ! Reason;
         M -> exit(M)
       end
     end),

--- a/src/test/resources/monitor.escript
+++ b/src/test/resources/monitor.escript
@@ -1,8 +1,8 @@
 #!/usr/bin/env escript
-%%! -smp enable -sname test@localhost -setcookie test
+%%! -sname monitor@localhost -setcookie test
 
 main([]) ->
-    {mbox,scala@localhost} ! self(),
+    {mbox_monitor, scala_monitor@localhost} ! self(),
     loop().
 
 loop() ->
@@ -25,6 +25,6 @@ loop() ->
     end.
 
 respond(Msg) ->
-    {scala,scala@localhost} ! Msg.
+    {scala_monitor, scala_monitor@localhost} ! Msg.
 
 

--- a/src/test/resources/receive_connection.escript
+++ b/src/test/resources/receive_connection.escript
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -smp enable -sname test@localhost -setcookie test
+%%! -sname receive_connection@localhost -setcookie test
 
 main([]) ->
   ok = net_kernel:monitor_nodes(true, [{node_type,all}]),

--- a/src/test/scala/scalang/NodeSpec.scala
+++ b/src/test/scala/scalang/NodeSpec.scala
@@ -104,6 +104,8 @@ class NodeSpec extends SpecificationWithJUnit {
         node.send(('echo, echo_host), mbox.self, (mbox.self, msg))
         mbox.receive(receiveTimeout) == (Some(msg))
       }) must beTrue
+      node.send(('echo, echo_host), mbox.self, (mbox.self, 'stop))
+      erl.waitFor
     }
 
     "receive remove regname" in {
@@ -122,6 +124,8 @@ class NodeSpec extends SpecificationWithJUnit {
         node.send(('echo, echo_host), mbox.self, ((mboxName, nodeName), msg))
         mbox.receive(receiveTimeout) == Some(msg)
       }) must beTrue
+      node.send(('echo, echo_host), mbox.self, ((mboxName, nodeName), 'stop))
+      erl.waitFor
     }
 
     "remove processes on exit" in {

--- a/src/test/scala/scalang/Poller.scala
+++ b/src/test/scala/scalang/Poller.scala
@@ -1,0 +1,29 @@
+package scalang
+
+object Poller {
+
+  type MilliSec = Long
+
+  val defaultTimeout = 5000
+  val defaultSleepInterval = 50
+
+  def waitFor(
+    condition : () => Boolean,
+    timeout : MilliSec = defaultTimeout,
+    sleepInterval : MilliSec = defaultSleepInterval
+  ) : Boolean = {
+    val limit = now + timeout
+    while (now < limit) {
+      if (condition()) {
+        return true
+      } else {
+        Thread.sleep(sleepInterval)
+      }
+    }
+    false
+  }
+
+  def now : MilliSec = {
+    System.currentTimeMillis
+  }
+}

--- a/src/test/scala/scalang/TestHelper.scala
+++ b/src/test/scala/scalang/TestHelper.scala
@@ -5,10 +5,11 @@ import java.lang.{Process => SysProcess}
 import java.io._
 import scala.collection.JavaConversions._
 import scala.collection.mutable.StringBuilder
+import scala.util.Random
 
 object ErlangVM {
   def apply(name : String, cookie : String, eval : Option[String]) : SysProcess = {
-    val commands = List("erl", "-sname", name, "-setcookie", cookie, "-noshell", "-smp") ++
+    val commands = List("erl", "-sname", name, "-setcookie", cookie, "-noshell") ++
       (for (ev <- eval) yield {
         List("-eval", ev)
       }).getOrElse(Nil)
@@ -36,11 +37,17 @@ object EpmdCmd {
 
 object ReadLine {
   def apply(proc : SysProcess) : String = {
-    val read = new BufferedReader(new InputStreamReader(proc.getInputStream))
-    val line = read.readLine
+    val reader = new BufferedReader(new InputStreamReader(proc.getInputStream))
+    val line = reader.readLine
     if(line == null) {
       throw new RuntimeException("error getting result from escript. ensure that erlang is installed and available on the path.")
     }
     line
+  }
+}
+
+object RandStr {
+  def apply(length : Int, alphabet : String = "0123456789abcdef") = {
+    (1 to length).map(_ => alphabet(Random.nextInt(alphabet.length))).mkString
   }
 }


### PR DESCRIPTION
Add distribution flags required by OTP 26, and improve robustness of `NodeSpec` so that tests pass consistently with OTP 26.