### PR TITLE
Avoid debug statement perf hit

### DIFF
--- a/src/main/scala/scalang/Node.scala
+++ b/src/main/scala/scalang/Node.scala
@@ -602,7 +602,10 @@ class ErlangNode(val name : Symbol, val cookie : String, config : NodeConfig) ex
       return
     }
 
-    log.debug("pids %s", processes.keys.toList)
+    if (log.isDebugEnabled) {
+        // skip running toList() if we don't intend to log it
+        log.debug("pids %s", processes.keys.toList)
+    }
     process(monitored) match {
       case Some(p) =>
         log.debug("adding monitor for %s", p)


### PR DESCRIPTION
The `log.debug("pids %s", processes.keys.toList)` line was showing up in a few stack traces when clouseau was timing out connecting to the erlang VM. The debug log line always translates the process map to a list, regardless if we're debugging or not.

To fix it, check for debug flag and run `toList()` only when debugging.
